### PR TITLE
fix: preserve incomplete scan semantics

### DIFF
--- a/shamash-asm-core/src/main/kotlin/io/shamash/asm/core/scan/bytecode/BytecodeScanner.kt
+++ b/shamash-asm-core/src/main/kotlin/io/shamash/asm/core/scan/bytecode/BytecodeScanner.kt
@@ -426,6 +426,10 @@ class BytecodeScanner {
                                 if (!e.name.endsWith(".class")) continue
 
                                 val entryName = e.name.replace('\\', '/')
+                                // Shamash's current scan contract has no target-runtime dimension.
+                                // Use the deterministic base JAR view rather than counting MR-JAR variants as separate classes.
+                                if (entryName.startsWith("META-INF/versions/")) continue
+
                                 val originId = "${origin.stablePath}!/$entryName"
                                 if (!seenOriginIds.add(originId)) continue
 

--- a/shamash-asm-core/src/test/kotlin/io/shamash/asm/core/scan/bytecode/BytecodeScannerTest.kt
+++ b/shamash-asm-core/src/test/kotlin/io/shamash/asm/core/scan/bytecode/BytecodeScannerTest.kt
@@ -24,9 +24,12 @@ import io.shamash.asm.core.config.schema.v1.model.ScanScope
 import org.junit.Assume
 import java.nio.file.Files
 import java.nio.file.Path
+import java.util.jar.JarEntry
+import java.util.jar.JarOutputStream
 import javax.tools.ToolProvider
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class BytecodeScannerTest {
@@ -75,6 +78,90 @@ class BytecodeScannerTest {
         }
     }
 
+    @Test
+    fun `multi release jar scans only base class entries`() {
+        val compiler = ToolProvider.getSystemJavaCompiler()
+        Assume.assumeNotNull(compiler)
+
+        val project = Files.createTempDirectory("shamash-asm-mrjar")
+        try {
+            val baseOut = project.resolve("mr-base")
+            val versionedOut = project.resolve("mr-versioned")
+            Files.createDirectories(baseOut)
+            Files.createDirectories(versionedOut)
+
+            compileJava(
+                project.resolve("base-src"),
+                "com.example.MultiRelease",
+                "package com.example; public class MultiRelease { public String value() { return \"base\"; } }",
+                baseOut,
+            )
+            compileJava(
+                project.resolve("versioned-src"),
+                "com.example.MultiRelease",
+                "package com.example; public class MultiRelease { public String value() { return \"v17\"; } }",
+                versionedOut,
+            )
+
+            val jar = project.resolve("libs/example.jar")
+            Files.createDirectories(jar.parent)
+            JarOutputStream(Files.newOutputStream(jar)).use { out ->
+                addJarEntry(out, baseOut.resolve("com/example/MultiRelease.class"), "com/example/MultiRelease.class")
+                addJarEntry(
+                    out,
+                    versionedOut.resolve("com/example/MultiRelease.class"),
+                    "META-INF/versions/17/com/example/MultiRelease.class",
+                )
+            }
+
+            val result =
+                BytecodeScanner().scan(
+                    projectBasePath = project,
+                    bytecode =
+                        BytecodeConfig(
+                            roots = listOf("."),
+                            outputsGlobs = GlobSet(include = emptyList(), exclude = emptyList()),
+                            jarGlobs = GlobSet(include = listOf("**/*.jar"), exclude = emptyList()),
+                        ),
+                    scan =
+                        ScanConfig(
+                            scope = ScanScope.PROJECT_ONLY,
+                            followSymlinks = false,
+                            maxClasses = null,
+                            maxJarBytes = null,
+                            maxClassBytes = null,
+                        ),
+                )
+
+            assertTrue(result.errors.isEmpty(), "scan should not report errors: ${result.errors}")
+            assertEquals(1, result.units.size, "versioned MR-JAR entries must not be scanned as separate logical classes")
+            assertTrue(
+                result.units
+                    .single()
+                    .originId
+                    .endsWith("!/com/example/MultiRelease.class"),
+            )
+            assertFalse(
+                result.units
+                    .single()
+                    .originId
+                    .contains("META-INF/versions/"),
+            )
+        } finally {
+            project.toFile().deleteRecursively()
+        }
+    }
+
+    private fun addJarEntry(
+        out: JarOutputStream,
+        source: Path,
+        entryName: String,
+    ) {
+        out.putNextEntry(JarEntry(entryName))
+        Files.copy(source, out)
+        out.closeEntry()
+    }
+
     private fun compileJava(
         tmp: Path,
         fqcn: String,
@@ -89,6 +176,7 @@ class BytecodeScannerTest {
 
         val srcDir = tmp.resolve("srcgen").resolve(pkgPath)
         Files.createDirectories(srcDir)
+        Files.createDirectories(outputDir)
 
         val javaFile = srcDir.resolve("$cls.java")
         Files.writeString(javaFile, source)

--- a/shamash-intellij-plugin/src/main/kotlin/io/shamash/intellij/plugin/psi/ui/actions/ExportPsiReportsAction.kt
+++ b/shamash-intellij-plugin/src/main/kotlin/io/shamash/intellij/plugin/psi/ui/actions/ExportPsiReportsAction.kt
@@ -83,6 +83,16 @@ class ExportPsiReportsAction(
                     return
                 }
 
+                if (result.engineErrors.isNotEmpty()) {
+                    PsiActionUtil.notify(
+                        project,
+                        "Shamash PSI",
+                        "Export skipped: scan incomplete (${result.engineErrors.size} engine errors).",
+                        NotificationType.WARNING,
+                    )
+                    return
+                }
+
                 val outDir = result.outputDir
                 val report = result.exportedReport
                 if (outDir == null || report == null) {

--- a/shamash-intellij-plugin/src/main/kotlin/io/shamash/intellij/plugin/psi/ui/actions/RunPsiScanAction.kt
+++ b/shamash-intellij-plugin/src/main/kotlin/io/shamash/intellij/plugin/psi/ui/actions/RunPsiScanAction.kt
@@ -34,6 +34,7 @@ import io.shamash.intellij.plugin.psi.ui.ShamashPsiToolWindowController
 import io.shamash.intellij.plugin.psi.ui.settings.ShamashPsiConfigLocator
 import io.shamash.psi.core.config.ValidationError
 import io.shamash.psi.core.config.ValidationSeverity
+import io.shamash.psi.core.engine.EngineError
 import io.shamash.psi.core.scan.ShamashProjectScanRunner
 import io.shamash.psi.core.scan.ShamashScanOptions
 import java.io.StringReader
@@ -87,6 +88,7 @@ class RunPsiScanAction(
     ) {
         object : Task.Backgroundable(project, "Shamash PSI Scan", true) {
             private var validationErrors: List<ValidationError> = emptyList()
+            private var engineErrors: List<EngineError> = emptyList()
             private var findings = emptyList<Finding>()
 
             override fun run(indicator: ProgressIndicator) {
@@ -107,6 +109,7 @@ class RunPsiScanAction(
                     )
 
                 validationErrors = result.configErrors
+                engineErrors = result.engineErrors
                 findings = result.findings
 
                 ProgressManager.checkCanceled()
@@ -129,6 +132,19 @@ class RunPsiScanAction(
                             project,
                             "Shamash PSI",
                             "Config invalid. Fix errors in Config tab.",
+                            NotificationType.WARNING,
+                        )
+                        return@invokeLater
+                    }
+
+                    if (engineErrors.isNotEmpty()) {
+                        tw.select(ShamashPsiToolWindowController.Tab.FINDINGS)
+                        tw.refreshAll()
+
+                        PsiActionUtil.notify(
+                            project,
+                            "Shamash PSI",
+                            "Scan incomplete: ${engineErrors.size} engine errors occurred during analysis. Partial findings are shown.",
                             NotificationType.WARNING,
                         )
                         return@invokeLater

--- a/shamash-psi-core/src/main/kotlin/io/shamash/psi/core/scan/ShamashProjectScanRunner.kt
+++ b/shamash-psi-core/src/main/kotlin/io/shamash/psi/core/scan/ShamashProjectScanRunner.kt
@@ -17,9 +17,7 @@
  */
 package io.shamash.psi.core.scan
 
-import com.intellij.notification.Notification
-import com.intellij.notification.NotificationType
-import com.intellij.notification.Notifications
+import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.ProgressManager
 import com.intellij.openapi.project.DumbService
@@ -35,6 +33,7 @@ import io.shamash.artifacts.util.glob.GlobMatcher
 import io.shamash.export.service.ShamashReportExportService
 import io.shamash.psi.core.config.ConfigValidation
 import io.shamash.psi.core.config.ValidationError
+import io.shamash.psi.core.config.ValidationSeverity
 import io.shamash.psi.core.config.schema.v1.model.ShamashPsiConfigV1
 import io.shamash.psi.core.engine.EngineError
 import io.shamash.psi.core.engine.ShamashPsiEngine
@@ -46,12 +45,23 @@ class ShamashProjectScanRunner(
     private val engine: ShamashPsiEngine = ShamashPsiEngine(),
     private val exportService: ShamashReportExportService = ShamashReportExportService(),
 ) {
+    private val log: Logger = Logger.getInstance(ShamashProjectScanRunner::class.java)
+
     data class ScanResult(
         val findings: List<Finding>,
         val exportedReport: ExportedReport?,
         val outputDir: Path?,
         val baselineWritten: Boolean,
         val configErrors: List<ValidationError> = emptyList(),
+        val engineErrors: List<EngineError> = emptyList(),
+    ) {
+        val isComplete: Boolean
+            get() = configErrors.none { it.severity == ValidationSeverity.ERROR } && engineErrors.isEmpty()
+    }
+
+    private data class FindingsScanResult(
+        val findings: List<Finding>,
+        val engineErrors: List<EngineError>,
     )
 
     fun scanProject(
@@ -74,14 +84,15 @@ class ShamashProjectScanRunner(
             )
         }
 
-        val findings = scanFindings(project, config, indicator)
+        val scan = scanFindings(project, config, indicator)
 
-        if (!options.exportReports) {
+        if (!options.exportReports || scan.engineErrors.isNotEmpty()) {
             return ScanResult(
-                findings = findings,
+                findings = scan.findings,
                 exportedReport = null,
                 outputDir = null,
                 baselineWritten = false,
+                engineErrors = scan.engineErrors,
             )
         }
 
@@ -91,14 +102,14 @@ class ShamashProjectScanRunner(
                 projectName = project.name,
                 toolName = options.toolName,
                 toolVersion = options.toolVersion,
-                findings = findings,
+                findings = scan.findings,
                 baseline = options.baseline,
                 exceptionsPreprocessor = null,
                 generatedAtEpochMillis = options.generatedAtEpochMillis,
             )
 
         return ScanResult(
-            findings = findings,
+            findings = scan.findings,
             exportedReport = exportResult.report,
             outputDir = exportResult.outputDir,
             baselineWritten = exportResult.baselineWritten,
@@ -109,7 +120,7 @@ class ShamashProjectScanRunner(
         project: Project,
         config: ShamashPsiConfigV1,
         indicator: ProgressIndicator,
-    ): List<Finding> {
+    ): FindingsScanResult {
         ProgressManager.checkCanceled()
 
         val psiManager = PsiManager.getInstance(project)
@@ -119,7 +130,7 @@ class ShamashProjectScanRunner(
         val excludeGlobs = config.project.sourceGlobs.exclude
 
         val roots = collectContentRoots(project)
-        if (roots.isEmpty()) return emptyList()
+        if (roots.isEmpty()) return FindingsScanResult(emptyList(), emptyList())
 
         val out = ArrayList<Finding>(1024)
         val engineErrors = ArrayList<EngineError>(256)
@@ -159,20 +170,44 @@ class ShamashProjectScanRunner(
             }
         }
 
-        if (engineErrors.isNotEmpty()) {
-            Notifications.Bus.notify(
-                Notification(
-                    "Shamash PSI",
-                    "Engine encountered ${engineErrors.size} errors",
-                    "${engineErrors.first().fileId}: ${engineErrors.first().phase} - ${engineErrors.first().message}\n" +
-                        "(see idea.log for full list)",
-                    NotificationType.WARNING,
-                ),
-                project,
-            )
+        val stableErrors =
+            engineErrors
+                .distinctBy { "${it.fileId}|${it.phase}|${it.ruleId ?: ""}|${it.message}|${it.throwableClass ?: ""}" }
+                .sortedWith(
+                    compareBy<EngineError>(
+                        { it.fileId },
+                        { it.phase },
+                        { it.ruleId ?: "" },
+                        { it.message },
+                        { it.throwableClass ?: "" },
+                    ),
+                )
+
+        if (stableErrors.isNotEmpty()) {
+            stableErrors.forEach { error ->
+                log.warn(
+                    buildString {
+                        append("PSI engine error")
+                        append(": file=")
+                        append(error.fileId)
+                        append(", phase=")
+                        append(error.phase)
+                        error.ruleId?.let {
+                            append(", rule=")
+                            append(it)
+                        }
+                        append(", message=")
+                        append(error.message)
+                        error.throwableClass?.let {
+                            append(", throwable=")
+                            append(it)
+                        }
+                    },
+                )
+            }
         }
 
-        return out
+        return FindingsScanResult(out, stableErrors)
     }
 
     private fun collectContentRoots(project: Project): List<VirtualFile> {

--- a/shamash-psi-core/src/test/kotlin/io/shamash/psi/core/ShamashProjectScanRunnerResultTest.kt
+++ b/shamash-psi-core/src/test/kotlin/io/shamash/psi/core/ShamashProjectScanRunnerResultTest.kt
@@ -1,0 +1,62 @@
+/*
+ * Copyright © 2025-2026 | Shamash
+ *
+ * Author: @aalsanie
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.shamash.psi.core
+
+import io.shamash.psi.core.engine.EngineError
+import io.shamash.psi.core.scan.ShamashProjectScanRunner
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ShamashProjectScanRunnerResultTest {
+    @Test
+    fun `engine errors make scan incomplete`() {
+        val result =
+            ShamashProjectScanRunner.ScanResult(
+                findings = emptyList(),
+                exportedReport = null,
+                outputDir = null,
+                baselineWritten = false,
+                engineErrors =
+                    listOf(
+                        EngineError(
+                            fileId = "src/main/java/com/example/Broken.java",
+                            phase = "rule:crash",
+                            message = "boom",
+                            throwableClass = IllegalStateException::class.java.name,
+                            ruleId = "arch.example",
+                        ),
+                    ),
+            )
+
+        assertFalse(result.isComplete)
+    }
+
+    @Test
+    fun `scan without config or engine errors is complete`() {
+        val result =
+            ShamashProjectScanRunner.ScanResult(
+                findings = emptyList(),
+                exportedReport = null,
+                outputDir = null,
+                baselineWritten = false,
+            )
+
+        assertTrue(result.isComplete)
+    }
+}


### PR DESCRIPTION
- Preserve PSI engine errors and mark affected scans as incomplete.
- Prevent report/baseline export from incomplete PSI scans.
- Avoid misleading clean-scan notifications when analysis partially fails.
- Ignore META-INF/versions/** when scanning multi-release JARs.
- Add regression tests for both cases.